### PR TITLE
Fix URL on the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Requires a **SmartNPC API key**. Create a SmartNPC account at https://smartnpc.a
 
 In Unity: Window -> Package Manager -> + -> Add package from git URL...
 
-URL: https://github.com/smartnpc/smartnpc-unity-sdk
+URL: https://github.com/smartnpc/smartnpc-unity-sdk.git
 
 ## Documentation
 


### PR DESCRIPTION
Using the current instructions to add the package, Unity is not able to find the package.
Adding the .git is needed. 

[Package Manager Window] Error adding package: https://github.com/smartnpc/smartnpc-unity-sdk.
Unable to add package [https://github.com/smartnpc/smartnpc-unity-sdk]:
  Package name 'https://github.com/smartnpc/smartnpc-unity-sdk' is invalid.
UnityEditor.EditorApplication:Internal_CallUpdateFunctions ()